### PR TITLE
Add an option to tint menu icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,15 @@ setStyle(@StyleRes int style)
 ```
 
 #Styling
-BottomSheet comes with both a Light and Dark theme to accomidate most scenarios. However, if you want to customize the color more, you can create your own style and supply it to the builder.
+BottomSheet comes with both a Light and Dark theme to accommodate most scenarios. However, if you want to customize the color more, you can create your own style and supply it to the builder.
 ```xml
 <style name="MyBottomSheetStyle" parent="@style/BottomSheet">
         <item name="bottom_sheet_bg_color">@color/my_color</item>
         <item name="bottom_sheet_title_color">@color/my_color_2</item>
         <item name="bottom_sheet_list_item_color">@color/my_color_3</item>
         <item name="bottom_sheet_grid_item_color">@color/my_color_4</item>
+        <!-- Tints the menu item icon to the specified color -->
+        <item name="bottom_sheet_item_icon_color">@color/my_color_5</item>
 </style>
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ setMenu(Menu menu)
 // Sets the MenuItems to be used
 setMenuItems(List<MenuItem> items)
 
+// Sets the tint color of the MenuItem icons
+setMenuItemTintColor(@ColorInt int menuItemTintColor)
+setMenuItemTintColorRes(@ColorRes int colorRes)
+
 // Sets the style 
 setStyle(@StyleRes int style)
 ```

--- a/library/src/main/java/com/kennyc/bottomsheet/BottomSheet.java
+++ b/library/src/main/java/com/kennyc/bottomsheet/BottomSheet.java
@@ -45,7 +45,8 @@ public class BottomSheet extends Dialog implements AdapterView.OnItemClickListen
             R.attr.bottom_sheet_bg_color,
             R.attr.bottom_sheet_title_color,
             R.attr.bottom_sheet_list_item_color,
-            R.attr.bottom_sheet_grid_item_color
+            R.attr.bottom_sheet_grid_item_color,
+            R.attr.bottom_sheet_item_icon_color
     };
 
     private Builder mBuilder;
@@ -140,6 +141,14 @@ public class BottomSheet extends Dialog implements AdapterView.OnItemClickListen
         Resources res = getContext().getResources();
         int listColor = ta.getColor(2, res.getColor(R.color.black_85));
         int gridColor = ta.getColor(3, res.getColor(R.color.black_85));
+
+        if (mBuilder.menuItemTintColor == Integer.MIN_VALUE) {
+            int itemIconColor = ta.getColor(4, Integer.MIN_VALUE);
+            if (itemIconColor != Integer.MIN_VALUE) {
+                mBuilder.menuItemTintColor = itemIconColor;
+            }
+        }
+
         mGrid.setAdapter(mAdapter = new GridAdapter(getContext(), mBuilder, listColor, gridColor));
     }
 
@@ -178,7 +187,7 @@ public class BottomSheet extends Dialog implements AdapterView.OnItemClickListen
         boolean isGrid = false;
 
         List<MenuItem> menuItems;
-        int menuItemTintColor = -1;
+        int menuItemTintColor = Integer.MIN_VALUE;
 
         Context context;
 
@@ -421,7 +430,7 @@ public class BottomSheet extends Dialog implements AdapterView.OnItemClickListen
             }
 
             Drawable menuIcon = item.getIcon();
-            if (mBuilder.menuItemTintColor != -1 && menuIcon != null) {
+            if (mBuilder.menuItemTintColor != Integer.MIN_VALUE && menuIcon != null) {
                 // mutate it, so we do not tint the original menu icon
                 menuIcon = menuIcon.mutate();
                 menuIcon.setColorFilter(new LightingColorFilter(Color.BLACK, mBuilder.menuItemTintColor));

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -5,5 +5,6 @@
     <attr name="bottom_sheet_title_color" format="color" />
     <attr name="bottom_sheet_list_item_color" format="color" />
     <attr name="bottom_sheet_grid_item_color" format="color" />
+    <attr name="bottom_sheet_item_icon_color" format="color" />
 
 </resources>


### PR DESCRIPTION
Used to change the color of menu item icons.

- setMenuItemTintColor - Takes the color int to tint the icons with

- setMenuItemTintColorRes - Takes a resource id as parameter, resolves the color and then calls setMenuItemTintColor(resolvedColor)

Example usage:
```
            final BottomSheet.Builder builder = new BottomSheet.Builder(mActivity);
            builder.setTitle(weirdThing.getTitle())
                    .setListener(appBottomSheetListener)
                    .setMenuItemTintColor(Color.GREEN);
```

Screenshots - I am applying the tint depending on the primary color of the app

![screenshot_2015-08-19-09-44-16](https://cloud.githubusercontent.com/assets/2779871/9351279/45663a9e-4658-11e5-825e-783565058d42.png)

![screenshot_2015-08-19-09-44-30](https://cloud.githubusercontent.com/assets/2779871/9351278/4563a798-4658-11e5-9a1e-fb71848ec604.png)