### PR TITLE
Updating gradle import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,11 @@ To include BottomSheet in your project, make the following changes to your build
 
 ## Add repository 
 ```groovy
-repositories {
-    maven { url "https://jitpack.io" }
+allprojects {
+    repositories {
+        ...
+        maven { url "https://jitpack.io" }
+    }
 }
 ```
 ## Add dependency


### PR DESCRIPTION
Add information, that jitpack.io respository must be added under `allprojects.repositories`, not in `buildscript.repositories`.