### PR TITLE
Make QUERY_ALL_PACKAGES permission not mandatory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.1.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion sdk_version
     flavorDimensions "default"
+    namespace "com.kennyc.bottomsheet"
 
     defaultConfig {
         minSdkVersion 21

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
     <application android:supportsRtl="true">
 
     </application>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.kennyc.bottomsheet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
     <application android:supportsRtl="true">
 

--- a/library/src/main/java/com/kennyc/bottomsheet/BottomSheetMenuDialogFragment.kt
+++ b/library/src/main/java/com/kennyc/bottomsheet/BottomSheetMenuDialogFragment.kt
@@ -1,5 +1,7 @@
 package com.kennyc.bottomsheet
 
+import android.Manifest
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.ComponentName
 import android.content.Context
@@ -11,6 +13,7 @@ import android.view.*
 import android.widget.*
 import androidx.annotation.IntegerRes
 import androidx.annotation.MenuRes
+import androidx.annotation.RequiresPermission
 import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -48,7 +51,9 @@ class BottomSheetMenuDialogFragment() : BottomSheetDialogFragment(),
          * @return A {@link BottomSheetMenuDialogFragment} with the apps that can handle the share intent. NULL maybe returned if no
          * apps can handle the share intent
          */
+        @SuppressLint("InlinedApi")
         @JvmStatic
+        @RequiresPermission(Manifest.permission.QUERY_ALL_PACKAGES)
         fun createShareBottomSheet(
             context: Context,
             intent: Intent,
@@ -121,7 +126,9 @@ class BottomSheetMenuDialogFragment() : BottomSheetDialogFragment(),
          * @return A [BottomSheetMenuDialogFragment] with the apps that can handle the share intent. NULL maybe returned if no
          * apps can handle the share intent
          */
+        @SuppressLint("InlinedApi")
         @JvmStatic
+        @RequiresPermission(Manifest.permission.QUERY_ALL_PACKAGES)
         fun createShareBottomSheet(
             context: Context,
             intent: Intent,
@@ -158,7 +165,9 @@ class BottomSheetMenuDialogFragment() : BottomSheetDialogFragment(),
          * @return A [BottomSheetMenuDialogFragment] with the apps that can handle the share intent. NULL maybe returned if no
          * apps can handle the share intent
          */
+        @SuppressLint("InlinedApi")
         @JvmStatic
+        @RequiresPermission(Manifest.permission.QUERY_ALL_PACKAGES)
         fun createShareBottomSheet(
             context: Context,
             intent: Intent,
@@ -193,7 +202,9 @@ class BottomSheetMenuDialogFragment() : BottomSheetDialogFragment(),
          * @return A [BottomSheetMenuDialogFragment] with the apps that can handle the share intent. NULL maybe returned if no
          * apps can handle the share intent
          */
+        @SuppressLint("InlinedApi")
         @JvmStatic
+        @RequiresPermission(Manifest.permission.QUERY_ALL_PACKAGES)
         fun createShareBottomSheet(
             context: Context,
             intent: Intent,
@@ -221,7 +232,9 @@ class BottomSheetMenuDialogFragment() : BottomSheetDialogFragment(),
          * @return A [BottomSheetMenuDialogFragment] with the apps that can handle the share intent. NULL maybe returned if no
          * apps can handle the share intent
          */
+        @SuppressLint("InlinedApi")
         @JvmStatic
+        @RequiresPermission(Manifest.permission.QUERY_ALL_PACKAGES)
         fun createShareBottomSheet(
             context: Context,
             intent: Intent,
@@ -248,7 +261,9 @@ class BottomSheetMenuDialogFragment() : BottomSheetDialogFragment(),
          * @return A [BottomSheetMenuDialogFragment] with the apps that can handle the share intent. NULL maybe returned if no
          * apps can handle the share intent
          */
+        @SuppressLint("InlinedApi")
         @JvmStatic
+        @RequiresPermission(Manifest.permission.QUERY_ALL_PACKAGES)
         fun createShareBottomSheet(
             context: Context,
             intent: Intent,

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion sdk_version
+    namespace "com.kennyc.bottomsheetsample"
 
     defaultConfig {
         applicationId "com.kennyc.bottomsheetsample"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.kennyc.bottomsheetsample" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Hello. I don't know if the library is still maintained, but here I go. You know what they say: Insanity is doing the same thing many times and expecting different results... or something like that. I'm insane, that's why I'm here.
Anyways, I resolved #70. Google has a way of expressing permission requirements in individual methods without declaring them in the manifest (and forcing the permission into users' apps) which I used.
I don't expect anything much, considering that the last commit is almost a year ago, but one has to have hope in life. Thank you for reading if you're still here.